### PR TITLE
Added technical program committee, a place where we can acknowledge track cochairs

### DIFF
--- a/components/MenuContent.vue
+++ b/components/MenuContent.vue
@@ -54,7 +54,10 @@
                         { label: 'Propose a talk or poster', to: "/talk-poster-cfp/" },
                         { label: 'Propose a tutorial', to: "/tutorial-cfp/" },
                         { label: 'Propose a sprint', to: "/sprint/" },
-                        'Financial Aid'
+                        'Financial Aid',
+                        { label: 'Technical Program Committee', to: '/participate/#tech-program-committee'},
+                        { label: 'Community Reviewers', to: '/participate/#Reviewers'}
+
                     ]
                 }, {
                     label: 'Program',

--- a/pages/participate.vue
+++ b/pages/participate.vue
@@ -83,18 +83,18 @@
         <BlockGreyOrange>
             <h1 id="tech-program-committee">Technical Program Committee</h1>
             <ul>
-            <li><b>Conference chair:</b> Lorena Barba</li>
-            <li><b>Conference cochair:</b> Sylvain Corlay</li>
+            <li><b>General Conference chair:</b> Lorena Barba</li>
+            <li><b>General Conference vice chair:</b> Sylvain Corlay</li>
             <li><b>Technical Program chair:</b> Jason Grout</li>
             <li><b>Tutorial cochairs:</b> Gerard Gorman, Tania Allard</li>
-            <li><b>Data Science Applications track cochairs:</b> Eric Ma, Gianluca Santarossa, Sarah Guido</li>
-            <li><b>Enterprise Jupyter Infrastructure track cochairs:</b> Rollin Thomas, Sarah Gibson</li>
-            <li><b>Jupyter Community: Tools and Practices track cochairs:</b> Doug Blank, Hannah Aizenman, Tony Hirst</li>
-            <li><b>Jupyter Core Technologies track cochairs:</b> M Pacer, Matthias Bussonier</li>
-            <li><b>Jupyter in Education track cochairs:</b> Elizabeth Wickes, Jason Williams</li>
-            <li><b>Jupyter in scientific research track cochairs:</b> Hans Fangohr, Lindsey Heagy</li>
-            <li><b>Lightning Talk track cochairs:</b> Paul Ivanov, Tracy Teal</li>
-            <li><b>Poster track cochairs:</b> Damian Avila, Julia Wagemann</li>
+            <li><b>Data Science Applications track co-chairs:</b> Eric Ma, Gianluca Santarossa, Sarah Guido</li>
+            <li><b>Enterprise Jupyter Infrastructure track co-chairs:</b> Rollin Thomas, Sarah Gibson</li>
+            <li><b>Jupyter Community: Tools and Practices track co-chairs:</b> Doug Blank, Hannah Aizenman, Tony Hirst</li>
+            <li><b>Jupyter Core Technologies track co-chairs:</b> M Pacer, Matthias Bussonier</li>
+            <li><b>Jupyter in Education track co-chairs:</b> Elizabeth Wickes, Jason Williams</li>
+            <li><b>Jupyter in scientific research track co-chairs:</b> Hans Fangohr, Lindsey Heagy</li>
+            <li><b>Lightning Talk track co-chairs:</b> Paul Ivanov, Tracy Teal</li>
+            <li><b>Poster track co-chairs:</b> Damian Avila, Julia Wagemann</li>
             </ul>
         </BlockGreyOrange>
 

--- a/pages/participate.vue
+++ b/pages/participate.vue
@@ -80,9 +80,27 @@
   
         </div>
 
-        <div class="tickets white-background" id="Reviewers">
+        <BlockGreyOrange>
+            <h1 id="tech-program-committee">Technical Program Committee</h1>
+            <ul>
+            <li><b>Conference chair:</b> Lorena Barba</li>
+            <li><b>Conference cochair:</b> Sylvain Corlay</li>
+            <li><b>Technical Program chair:</b> Jason Grout</li>
+            <li><b>Tutorial cochairs:</b> Gerard Gorman, Tania Allard</li>
+            <li><b>Data Science Applications track cochairs:</b> Eric Ma, Gianluca Santarossa, Sarah Guido</li>
+            <li><b>Enterprise Jupyter Infrastructure track cochairs:</b> Rollin Thomas, Sarah Gibson</li>
+            <li><b>Jupyter Community: Tools and Practices track cochairs:</b> Doug Blank, Hannah Aizenman, Tony Hirst</li>
+            <li><b>Jupyter Core Technologies track cochairs:</b> M Pacer, Matthias Bussonier</li>
+            <li><b>Jupyter in Education track cochairs:</b> Elizabeth Wickes, Jason Williams</li>
+            <li><b>Jupyter in scientific research track cochairs:</b> Hans Fangohr, Lindsey Heagy</li>
+            <li><b>Lightning Talk track cochairs:</b> Paul Ivanov, Tracy Teal</li>
+            <li><b>Poster track cochairs:</b> Damian Avila, Julia Wagemann</li>
+            </ul>
+        </BlockGreyOrange>
 
-            <h1>Community Reviewers</h1>
+        <div class="tickets white-background">
+
+        <h1 id="Reviewers">Community Reviewers</h1>
             <p>
             We would like to thank all of the community reviewers who reviewed talk, poster, and tutorial proposals. Listed below are the reviewers who completed all of their requested reviews by the deadline. Thank you!
             </p>


### PR DESCRIPTION
I was trying to acknowledge people directly involved in the parts of the conference on this page (tutorials, the in-conference program, etc.) - are there other people to add here?

On the other hand, perhaps we just restrict this to the listing of track co-chairs, since others are listed in the organizing committtee page?
