### PR TITLE
Remove the links to the cfp site

### DIFF
--- a/pages/talk-poster-cfp.vue
+++ b/pages/talk-poster-cfp.vue
@@ -25,7 +25,7 @@
             <p>
             Authors submit proposals by <s>Monday, July 20, 2020</s> Wednesday, July 22, 2020 (<a href="https://en.wikipedia.org/wiki/Anywhere_on_Earth">Anywhere on Earth</a>)<br/>
             Authors receive proposal accept/decline decision August 10-12, 2020<br/>
-            Authors upload talks by September 11, 2020<br/>
+            Authors upload talks by <s>September 11, 2020</s> September 18, 2020<br/>
             </p>
 
             <a class="button" :href="pyDataBaseUrl">Proposal System (Submissions are closed)</a>

--- a/pages/talk-poster-cfp.vue
+++ b/pages/talk-poster-cfp.vue
@@ -10,9 +10,11 @@
                 <h2>Propose a talk or poster</h2>
                     <slot>What lessons do you have to share with the Jupyter community? Have you developed good workflows using Jupyter? Have you solved tricky Jupyter deployment challenges? Do you have a great tool for the Jupyter community? Do you have an interesting application using Jupyter? What do you wish you would have known when starting to use Jupyter?  Propose a talk or poster at the JupyterCon!
                     </slot>
+                    <br>
+                    <br>
                     <slot>
-                                <a class="button" style="border-color: white; color: white; margin-top: 20px"  :href="pyDataBaseUrl">Proposal System (Submissions are closed)</a>
-                                </slot>
+                    <em>Proposal submissions are now closed.</em>
+                    </slot>
                 </div>
 
             </template>
@@ -27,8 +29,6 @@
             Authors receive proposal accept/decline decision August 10-12, 2020<br/>
             Authors upload talks by <s>September 11, 2020</s> September 18, 2020<br/>
             </p>
-
-            <a class="button" :href="pyDataBaseUrl">Proposal System (Submissions are closed)</a>
 
             <h2>Talks at JupyterCon 2020</h2>
 

--- a/pages/tutorial-cfp.vue
+++ b/pages/tutorial-cfp.vue
@@ -40,7 +40,7 @@ https://www.flickr.com/photos/oreillyconf/44286557691/in/album-72157698903074851
             <p>
             Authors submit proposals by <s>Monday, July 20, 2020</s> Wednesday, July 22, 2020 (<a href="https://en.wikipedia.org/wiki/Anywhere_on_Earth">Anywhere on Earth</a>)<br/>
             Authors receive proposal accept/decline decision August 10-12, 2020<br/>
-            Authors upload talks by September 11, 2020<br/>
+            Authors upload talks by <s>September 11, 2020</s> September 18, 2020<br/>
             </p>
 
             <a class="button" :href="pyDataBaseUrl">Proposal System (Submissions are closed)</a>

--- a/pages/tutorial-cfp.vue
+++ b/pages/tutorial-cfp.vue
@@ -25,9 +25,11 @@ https://www.flickr.com/photos/oreillyconf/44286557691/in/album-72157698903074851
                 <h2>Propose a tutorial</h2>
                     <slot> The JupyterCon organizing committee would like to invite all commmunity members to submit a tutorial for JupyterCon 2020. 
                     </slot>
+                    <br>
+                    <br>
                     <slot>
-                                <a class="button" style="border-color: white; color: white; margin-top: 20px"  :href="pyDataBaseUrl">Proposal System (Submissions are closed)</a>
-                                </slot>
+                    <em>Proposal submissions are now closed.</em>
+                    </slot>
                 </div>
 
             </template>
@@ -42,8 +44,6 @@ https://www.flickr.com/photos/oreillyconf/44286557691/in/album-72157698903074851
             Authors receive proposal accept/decline decision August 10-12, 2020<br/>
             Authors upload talks by <s>September 11, 2020</s> September 18, 2020<br/>
             </p>
-
-            <a class="button" :href="pyDataBaseUrl">Proposal System (Submissions are closed)</a>
 
             <h2>Guidelines for proposal submission</h2>
 


### PR DESCRIPTION
As discussed in the organization call this morning, this removes the links to the cfp site.

Also, it updates the talk upload dates to Sep 18.